### PR TITLE
I18n: Add text domain to welcome title

### DIFF
--- a/scripts/config-app/components/about/index.js
+++ b/scripts/config-app/components/about/index.js
@@ -11,7 +11,7 @@ function About({ onCreateTemplate }) {
 
   return (
     <div className="gcf-about">
-      <h1>{__("Welcome to Gutenberg Custom Fields")}</h1>
+      <h1>{__("Welcome to Gutenberg Custom Fields", "gutenberg-custom-fields")}</h1>
       <p>
         {__(
           "Gutenberg Custom Fields allows you to control the content of the Gutenberg edit screen by creating pre-filled templates.",


### PR DESCRIPTION
This PR adds the text domain to the `Welcome to Gutenberg Custom Fields` string, so the translation is displayed.